### PR TITLE
landingpage: Recommend installation on Windows with winget

### DIFF
--- a/src/components/LandingPage/DownloadSection.tsx
+++ b/src/components/LandingPage/DownloadSection.tsx
@@ -29,7 +29,7 @@ const downloadInfo: Record<Platform, DownloadInfo> = {
     label: "Download for Windows",
     fallbackDownloadLink:
       "/docs/latest/installation/desktop/windows-installation",
-    script: "choco install headlamp",
+    script: "winget install headlamp",
   },
   mac: {
     label: "Download for macOS",


### PR DESCRIPTION
Instead of choco. Just because users are likely to have winget already.