### PR TITLE
docs: include installation step via Glasskube

### DIFF
--- a/docs/latest/installation/in-cluster/index.md
+++ b/docs/latest/installation/in-cluster/index.md
@@ -29,6 +29,16 @@ helm install my-headlamp headlamp/headlamp --namespace kube-system -f values.yam
 helm install my-headlamp headlamp/headlamp --namespace kube-system --set replicaCount=2
 ```
 
+## Using Glasskube
+To install Headlamp using [Glasskube](https://glasskube.dev/), you can select "Headlamp" from the "ClusterPackages" tab in the Glasskube GUI then click "install" or you can run the following command:
+```
+glasskube install headlamp
+```
+Once Headlamp is installed you can access the Headlamp dashboard by clicking "open" in the Glasskube GUI or by using the open command:
+```
+glasskube open headlamp
+```
+
 ## Using simple yaml
 
 We also maintain a simple/vanilla [file](https://github.com/headlamp-k8s/headlamp/blob/main/kubernetes-headlamp.yaml)

--- a/src/components/LandingPage/DownloadPlatformsSection.tsx
+++ b/src/components/LandingPage/DownloadPlatformsSection.tsx
@@ -136,6 +136,18 @@ helm install my-headlamp headlamp/headlamp --namespace kube-system`}
               Get the Docker Desktop Extension <IconExternalLink />
             </Link>
           </TabItem>
+          <TabItem value="glasskube" label="Glasskube">
+            <p>
+              Install Headlamp in your cluster using{" "}
+              <Link href="https://glasskube.dev/">Glasskube</Link>. Run the following:
+            </p>
+            <CodeBlock language="bash" className="fit-content">
+              {`glasskube install headlamp`}
+            </CodeBlock>
+            <Link to="/docs/latest/installation/in-cluster/#using-glasskube">
+              Learn more
+            </Link>
+          </TabItem>
         </Tabs>
       </div>
     </>


### PR DESCRIPTION
Hey there this is Jake from [Glasskube](https://glasskube.dev/) (a package manager for Kubernetes). 

I just wanted to let you know that we now officially support Headlamp. Making it super easy for Headlamp users to use the GUI or CLI to install (allowing auto-updates) and access to an in-cluster deployment of Headlamp. 

I aim to add through this PR a section to the docs that adds some instructions on how to utilise Glasskube for Headlamp installation. I'm also attaching some screenshots so you can see what headlamp looks like in the Glasskube UI. 

Thanks for you time and great work with Headlamp. 

- Jake

![Screenshot 2024-07-12 at 11 22 55](https://github.com/user-attachments/assets/ed0756d9-fcc9-4522-b6b7-fd8edfbb9600)
![Screenshot 2024-07-12 at 11 22 44](https://github.com/user-attachments/assets/92b53fe7-3468-4e19-afb6-a9bae34dfa5e)
![Screenshot 2024-07-18 at 11 30 03](https://github.com/user-attachments/assets/92d6ce35-4ece-42e1-8165-b138852507d2)
