### PR TITLE
blog: Add YYYY/MM redirects

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,8 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import { githubA11yLight } from "./src/prismColorTheme";
 
+const dateForRedirects = new Date(2024, 7, 1);
+
 const config: Config = {
   title: "Headlamp",
   tagline: "Headlamp is a user-friendly Kubernetes UI focused on extensibility",
@@ -30,6 +32,29 @@ const config: Config = {
         }
       };
     },
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          // Check if the path matches /blog/YYYY/MM/DD/...
+          const blogPostRegex = /^\/blog\/(\d{4})\/(\d{2})\/(\d{2})\/(.+)/;
+          const match = existingPath.match(blogPostRegex);
+          if (match) {
+            const [_, year, month, _day, path] = match;
+
+            // Only redirect for posts before July 2024, when we launched the new website,
+            // with the new blog post URL structure.
+            const postDate = new Date(year, month);
+            if (postDate < dateForRedirects) {
+              // Redirect to /blog/YYYY/MM/...
+              return [`/blog/${year}/${month}/${path}`];
+            }
+          }
+
+          return undefined;
+        },
+      },
+    ],
   ],
 
   // Even if you don't use internationalization, you can use this field to set

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.4.0",
+        "@docusaurus/plugin-client-redirects": "3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-brands-svg-icons": "^6.5.2",
@@ -2350,6 +2351,29 @@
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1",
         "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.4.0.tgz",
+      "integrity": "sha512-Pr8kyh/+OsmYCvdZhc60jy/FnrY6flD2TEAhl4rJxeVFxnvvRgEhoaIVX8q9MuJmaQoh6frPk94pjs7/6YgBDQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -8761,19 +8785,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",
+    "@docusaurus/plugin-client-redirects": "3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.2",


### PR DESCRIPTION
This patch adds redirects from blog/YYYY/MM/DD/post to blog/YYYY/MM/post, so it's compatible with older style blog posts. It only does the redirection for posts prior to July 2024.