### PR TITLE
styles: Add styles for figure with figcaption

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -123,3 +123,13 @@ html[data-theme="dark"] {
 .search-icon {
   display: none;
 }
+
+figure > p {
+  margin: 0;
+}
+
+figcaption {
+  text-align: center;
+  font-style: italic;
+  opacity: 0.8;
+}


### PR DESCRIPTION
This allows adding an image with a caption that looks decent 

For example:

![image](https://github.com/user-attachments/assets/214c984a-2b42-4b30-a015-7b70299543d0)