### PR TITLE
The Headlamp folder installed during the 'npm install' instruction fr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+/headlamp
 docs/*


### PR DESCRIPTION
…om the headlamp repository will no more be part of the git tracking as it has been included in the .gitignore file