### PR TITLE
blog: Remove non-published authors from list

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,53 +1,11 @@
-alban-crequy:
-  name: Alban Crequy
 ashu-ghildiyial:
   name: Ashu Ghildiyal
 ashu:
   name: Ashu Ghildiyal
-alessandro-puccetti:
-  name: Alessandro Puccetti
-kosy-anyanwu:
-  name: Kosy Anyanwu
 andrew-randall:
   name: Andrew Randall
-indra-gupta:
-  name: Indradhanush Gupta
-lexi-nadolski:
-  name: Lexi Nadolski
-mateusz-gozdek:
-  name: Mateusz Gozdek
-lili:
-  name: Lili Cosic
-michael-schubert:
-  name: Michael Schubert
-zeeshan-ali:
-  name: Zeeshan Ali
-thilo-fromm:
-  name: Thilo Fromm
-mauricio-vasquez:
-  name: Mauricio Vásquez Bernal
-kai-lueke:
-  name: Kai Lüke
-lorenzo-manacorda:
-  name: Lorenzo Manacorda
-krzesimir-nowak:
-  name: Krzesimir Nowak
 chris-kuehl:
   name: Chris Kühl
-suraj-deshmukh:
-  name: Suraj Deshmukh
-iago-lopez:
-  name: Iago López Galeiras
-rodrigo-campos:
-  name: Rodrigo Campos
-johannes-liebermann:
-  name: Johannes Liebermann
-dongsu-park:
-  name: Dongsu Park
-jeremi-piotrowski:
-  name: Jeremi Piotrowski
-mathieu-tortuyaux:
-  name: Mathieu Tortuyaux
 santhosh-nagaraj:
   name: Santhosh Nagaraj
 joaquim-rocha:


### PR DESCRIPTION
They were there due to old Kinvolk blog's migration.