### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,10 +11682,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "10.9.3",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.3.tgz",
-      "integrity": "sha512-V80X1isSEvAewIL3xhmz/rVmc27CVljcsbWxkxlWJWY/1kQa4XOABqpDl2qQLGKzpKm6WbTfUEKImBlUfFYArw==",
-      "license": "MIT",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.4.tgz",
+      "integrity": "sha512-VIG2B0R9ydvkS+wShA8sXqkzfpYglM2Qwj7VyUeqzNVqSGPoP/tcaUr3ub4ESykv8eqQJn3p99bHNvYdg3gCHQ==",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.1",
         "@types/d3-scale": "^4.0.3",


### PR DESCRIPTION
This change updates the following dependencies:
- `dompurify` from `3.1.6` to `3.2.6`
- `on-headers` from `1.0.2` to `1.1.0`
- `mermaid` from `10.9.3` to `10.9.4`