### PR TITLE
Fix brew install (missing cask)

### DIFF
--- a/src/components/LandingPage/DownloadSection.tsx
+++ b/src/components/LandingPage/DownloadSection.tsx
@@ -34,7 +34,7 @@ const downloadInfo: Record<Platform, DownloadInfo> = {
   mac: {
     label: "Download for macOS",
     fallbackDownloadLink: "/docs/latest/installation/desktop/mac-installation",
-    script: "brew install headlamp",
+    script: "brew install --cask headlamp",
   },
   linux: {
     label: "Download for Linux",


### PR DESCRIPTION
Source of truth:

https://github.com/kubernetes-sigs/headlamp/blob/a7b35c162ba0e7d9c91f869bd67db533f56d4c83/docs/installation/desktop/mac-installation.md?plain=1#L12

https://github.com/kubernetes-sigs/headlamp/blob/main/docs/installation/desktop/mac-installation.md#install-via-homebrew