### PR TITLE
PluginsPage/Carousel: Fix image issue with plugins/ path

### DIFF
--- a/src/components/PluginsPage/Carousel.tsx
+++ b/src/components/PluginsPage/Carousel.tsx
@@ -80,7 +80,7 @@ export function Carousel() {
                     >
                         <div>
                             <a href={items[activeIndex].href} className={stylesPlugin.cardLink} target="_blank" rel="noreferrer">
-                                <img src={items[activeIndex].imageSrc} alt={items[activeIndex].imageAlt} className={stylesPlugin.cardImage} loading="lazy" />
+                                <img src={"/" + items[activeIndex].imageSrc} alt={items[activeIndex].imageAlt} className={stylesPlugin.cardImage} loading="lazy" />
                             </a>
                         </div>
                         <div className={stylesPlugin.featureCardBody}>


### PR DESCRIPTION
Before when path is plugins/ it doesn't work.
At plugins it works for both.


Note: currently https://headlamp.dev/plugins goes to "https://headlamp.dev/plugins/" which causes the image paths to be wrong.

