### PR TITLE
Add Learn link to footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -176,6 +176,11 @@ const config: Config = {
           label: "Docs",
         },
         {
+          to: "/docs/latest/learn",
+          label: "Learn",
+          position: "left",
+        },
+        {
           href: "https://kubernetes.slack.com/messages/headlamp",
           label: "Slack",
           position: "right",
@@ -244,6 +249,10 @@ const config: Config = {
             {
               label: "F.A.Q.",
               href: "/docs/latest/faq",
+            },
+            {
+              label: "Learn",
+              href: "/docs/latest/learn",
             },
           ],
         },


### PR DESCRIPTION
## Description

Note: This is a update PR that is meant to fix the Learn documents not rendering in the live webpage. Adding this placeholder should cause the repo to build again and fix the missing Learn docs.

This PR will add a link in the footer that will navigate to the new Learn section docs. 

This is a placeholder for now as we do not have enough content for the base /docs/latest/learn page yet.

<img width="1753" height="639" alt="image" src="https://github.com/user-attachments/assets/32577ce1-aa38-4e25-8ee5-9e3b86ccacc6" />
