### PR TITLE
DownloadPlatformsSection: DownloadSection: Add warning near download link

### DIFF
--- a/src/components/LandingPage/DownloadPlatformsSection.tsx
+++ b/src/components/LandingPage/DownloadPlatformsSection.tsx
@@ -49,6 +49,49 @@ export function DownloadPlatformsContent() {
                   <CodeBlock language="bash">choco install headlamp</CodeBlock>
                 </div>
               </div>
+              <div
+                className={styles.announcement}
+                style={{
+                  backgroundColor: "#f2e600",
+                  color: "#070f7f",
+                  padding: "12px",
+                  borderRadius: "4px",
+                }}
+                role="note"
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    marginRight: 8,
+                    color: "#f2a900",
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M1 21h22L12 2 1 21zM13 18h-2v-2h2v2zm0-4h-2V10h2v4z" />
+                  </svg>
+                </span>
+                <strong>Important:</strong>{" "}
+                <span>
+                  On warnings from Windows{" "}
+                  <Link
+                    to="/docs/latest/installation/desktop/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "inherit", textDecoration: "underline" }}
+                  >
+                    when running Headlamp unsigned apps.
+                  </Link>
+                </span>
+              </div>
             </FlexContent>
           </TabItem>
           <TabItem value="linux" label="Linux">
@@ -80,6 +123,52 @@ export function DownloadPlatformsContent() {
                 <CodeBlock language="bash">
                   brew install --cask headlamp
                 </CodeBlock>
+              </div>
+
+
+
+              <div
+                className={styles.announcement}
+                style={{
+                  backgroundColor: "#f2e600",
+                  color: "#070f7f",
+                  padding: "12px",
+                  borderRadius: "4px",
+                }}
+                role="note"
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    marginRight: 8,
+                    color: "#f2a900",
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M1 21h22L12 2 1 21zM13 18h-2v-2h2v2zm0-4h-2V10h2v4z" />
+                  </svg>
+                </span>
+                <strong>Important:</strong>{" "}
+                <span>
+                  On warnings from Mac{" "}
+                  <Link
+                    to="/docs/latest/installation/desktop/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "inherit", textDecoration: "underline" }}
+                  >
+                    when running Headlamp unsigned apps.
+                  </Link>
+                </span>
               </div>
             </FlexContent>
           </TabItem>

--- a/src/components/LandingPage/DownloadSection.tsx
+++ b/src/components/LandingPage/DownloadSection.tsx
@@ -167,6 +167,48 @@ function DownloadSection({ forcePlatform }: { forcePlatform?: Platform }) {
           </>
         )}
       </div>
+      {(platform === "win" || platform === "mac") && (
+        <div
+          className={styles.announcement}
+          style={{
+            padding: "12px",
+            borderRadius: "4px",
+          }}
+          role="note"
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              marginRight: 8,
+              color: "#f2a900",
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M1 21h22L12 2 1 21zM13 18h-2v-2h2v2zm0-4h-2V10h2v4z" />
+            </svg>
+          </span>
+          <strong>Important:</strong>{" "}
+          <span>
+            On warnings from Mac and Windows{" "}
+            <Link
+              to="/docs/latest/installation/desktop/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              when running Headlamp unsigned apps.
+            </Link>
+          </span>
+        </div>
+      )}
       {platform !== "unknown" && (
         <Link
           to="#download-platforms"


### PR DESCRIPTION
This adds warnings closer to the download links on Mac and Windows.

Still had people reporting this issue, and this was a request from one of those people.

<img width="767" height="308" alt="Screenshot 2025-11-17 at 14 12 53" src="https://github.com/user-attachments/assets/1d89d1d6-6866-4efd-ad17-e04a77816a00" />

<img width="820" height="286" alt="Screenshot 2025-11-17 at 14 13 17" src="https://github.com/user-attachments/assets/5b361f67-ca99-464d-bdae-b9170d5c4666" />
