### PR TITLE
Remove Learn from top nav

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -211,11 +211,6 @@ const config: Config = {
           label: "Docs",
         },
         {
-          to: "/docs/latest/learn",
-          label: "Learn",
-          position: "left",
-        },
-        {
           href: "https://kubernetes.slack.com/messages/headlamp",
           label: "Slack",
           position: "right",


### PR DESCRIPTION
## About

This PR reverts the change that added the Learn tab to the top navbar, everything else remains the same as it was before.

Top nav before: Home / Blog / Plugins / Docs / Learn

Top nav after: Home / Blog / Plugins / Docs

The nav as of these changes:
<img width="1888" height="403" alt="image" src="https://github.com/user-attachments/assets/70fc3713-c37a-4701-b5b3-2bd241255a95" />



As requested from @joaquimrocha 