### PR TITLE
feat: add kubevirt plugin to plugins catalog

### DIFF
--- a/src/components/PluginsPage/PluginData/headlamp_kubevirt.js
+++ b/src/components/PluginsPage/PluginData/headlamp_kubevirt.js
@@ -1,0 +1,86 @@
+// created via add-plugin.js
+    const headlamp_kubevirt = {
+    "version": "0.2.2",
+    "digest": "2026-04-28T10:00:00Z",
+    "name": "headlamp_kubevirt",
+    "displayName": "KubeVirt",
+    "createdAt": "2025-03-23T00:00:00Z",
+    "description": "A comprehensive Headlamp plugin for managing KubeVirt virtual machines in Kubernetes",
+    "license": "Apache-2.0",
+    "homeURL": "https://github.com/naval-group/headlamp-kubevirt",
+    "logoURL": "https://raw.githubusercontent.com/kubevirt/community/main/logo/KubeVirt_icon.png",
+    "containsSecurityUpdates": true,
+    "operator": false,
+    "prerelease": false,
+    "keywords": [
+        "headlamp",
+        "kubevirt",
+        "kubernetes",
+        "virtualization",
+        "virtual-machine",
+        "vnc",
+        "vm-templates",
+        "forensics",
+        "s3"
+    ],
+    "provider": {
+        "name": "Naval Group"
+    },
+    "maintainers": [
+        {
+            "name": "Alexandre Knecht",
+            "email": "knecht.alexandre@gmail.com"
+        },
+        {
+            "name": "Aymeric Deliencourt",
+            "email": "aymeric.deliencourt@aydev.fr"
+        }
+    ],
+    "links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/naval-group/headlamp-kubevirt"
+        },
+        {
+            "name": "Image Catalog Documentation",
+            "url": "https://github.com/naval-group/headlamp-kubevirt/blob/main/docs/image-catalog/README.md"
+        }
+    ],
+    "screenshots": [
+        {
+            "title": "Overview Dashboard",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/overview-dashboard.png"
+        },
+        {
+            "title": "VM Details",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/vm-details.png"
+        },
+        {
+            "title": "Serial Console",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/serial-console.png"
+        },
+        {
+            "title": "VNC Console",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/vnc-console.png"
+        },
+        {
+            "title": "Create VM",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/create-vm.png"
+        },
+        {
+            "title": "Settings",
+            "url": "https://raw.githubusercontent.com/naval-group/headlamp-kubevirt/main/screenshots/settings.png"
+        }
+    ],
+    "install": "## Desktop Installation\n\nDownload the latest release tarball and extract to your Headlamp plugins directory:\n\n```bash\ntar -xzf headlamp-kubevirt-*.tar.gz -C ~/.config/Headlamp/plugins/\n```\n\n## In-Cluster Installation\n\nAdd as an init container to your Headlamp deployment:\n\n```yaml\ninitContainers:\n  - name: headlamp-kubevirt\n    image: ghcr.io/naval-group/headlamp-kubevirt:latest\n    command: [\"/bin/sh\", \"-c\"]\n    args: [\"cp -r /plugins/kubevirt /headlamp-plugins/\"]\n    volumeMounts:\n      - name: headlamp-plugins\n        mountPath: /headlamp-plugins\n```\n",
+    "annotations": {
+        "headlamp/plugin/archive-url": "https://github.com/naval-group/headlamp-kubevirt/releases/download/v0.2.2/headlamp-kubevirt-0.2.2.tar.gz",
+        "headlamp/plugin/archive-checksum": "sha256:69416eea8c26d13e4379318a218503faab4d637914f462cc4fe90bdc19b0247e",
+        "headlamp/plugin/version-compat": ">=0.24.0",
+        "headlamp/plugin/distro-compat": "in-cluster,desktop,docker-desktop,web"
+    },
+    "githubURL": "https://github.com/naval-group/headlamp-kubevirt/blob/main"
+};
+
+    export default headlamp_kubevirt;
+    

--- a/src/components/PluginsPage/PluginData/index.js
+++ b/src/components/PluginsPage/PluginData/index.js
@@ -7,6 +7,7 @@ import headlamp_karpenter from './headlamp_karpenter.js';
 import headlamp_keda from './headlamp_keda.js';
 import headlamp_knative from './headlamp_knative.js';
 import headlamp_kubescape from './headlamp_kubescape.js';
+import headlamp_kubevirt from './headlamp_kubevirt.js';
 import headlamp_minikube from './headlamp_minikube.js';
 import headlamp_opencost from './headlamp_opencost.js';
 import headlamp_trivy from './headlamp_trivy.js';
@@ -23,6 +24,7 @@ const allPluginsData = [
     headlamp_keda,
     headlamp_knative,
     headlamp_kubescape,
+    headlamp_kubevirt,
     headlamp_minikube,
     headlamp_opencost,
     headlamp_trivy,


### PR DESCRIPTION
## Summary

This PR adds the **KubeVirt** plugin to the Headlamp plugins catalog (`headlamp.dev/plugins/`).

- Plugin repo: https://github.com/naval-group/headlamp-kubevirt
- Generated via `npm run add-plugin` from the plugin's `artifacthub-pkg.yml`
- Adds `src/components/PluginsPage/PluginData/headlamp_kubevirt.js` and registers it in `index.js`

## Context

**This is not an official plugin maintained by the KubeVirt maintainers**. This is clearly stated in the project's README. It is a community-maintained plugin.

> Disclaimer: This is an independent community plugin. It is not maintained by, affiliated with, or endorsed by the [KubeVirt](https://kubevirt.io/) project. For KubeVirt issues, please use the [KubeVirt issue tracker](https://github.com/kubevirt/kubevirt/issues). For issues with this plugin, please use [our issue tracker](https://github.com/naval-group/headlamp-kubevirt/issues).

That said, it is by far the most advanced KubeVirt plugin for Headlamp available today: it aims to turn Headlamp + KubeVirt on Kubernetes into a virtualization platform as simple and intuitive to use as Proxmox (VM lifecycle management, serial & VNC consoles, VM templates, image catalog, etc.).

An earlier, unofficial KubeVirt plugin also existed, but with significantly fewer features. It is no longer maintained and has been archived by its maintainer (see https://github.com/buttahtoast/headlamp-plugins/issues/51), so there is no overlap or conflict with an actively maintained listing.

  ## Test plan

  - [x] `npm start` and open `http://localhost:3000/plugins/` — verify the **KubeVirt** card appears in the catalog
  - [x] Verify logo, description, screenshots and links render correctly
  - [x] Verify the install instructions display as expected