### PR TITLE
update footer according to LFX LLC rules

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -293,10 +293,8 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright ${new Date().getFullYear()} The Kubernetes Authors<br />
-      The Linux Foundation® (TLF) has registered trademarks and uses trademarks.<br />
-      For a list of TLF trademarks, see <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">
-      Trademark Usage</a>`,
+      copyright: `Copyright Headlamp a Series of LF Projects, LLC<br />
+      For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank">https://lfprojects.org/policies/</a>.`,
     },
     prism: {
       additionalLanguages: ["bash", "yaml", "docker"],


### PR DESCRIPTION
<img width="869" height="170" alt="image" src="https://github.com/user-attachments/assets/5ecaede3-2b2e-4fb0-ab05-9fd44a61241a" />

The update involved changing the website footer's copyright notice to comply with the new LF Projects Series LLC trademark disclaimer guidelines.

Specifically, I modified the docusaurus.config.ts configuration file, which controls the overall site layout and metadata for the Headlamp website.

The changes were:

Removed the old copyright string referencing "The Kubernetes Authors" and the old Linux Foundation trademark notice.
Added the new required text: Copyright Headlamp a Series of LF Projects, LLC
Added the required link pointing to the new terms and policies page: For website terms of use, trademark policy and other project policies please see https://lfprojects.org/policies/.
This ensures that the project correctly attributes its copyright to its new legal entity status as a Series of LF Projects, LLC, fulfilling the acceptance criteria of issue #125.