### PR TITLE
DownloadSection: Fix latest release fetching and fix fallback URL for windows

### DIFF
--- a/src/components/LandingPage/DownloadSection.tsx
+++ b/src/components/LandingPage/DownloadSection.tsx
@@ -28,7 +28,7 @@ const downloadInfo: Record<Platform, DownloadInfo> = {
   win: {
     label: "Download for Windows",
     fallbackDownloadLink:
-      "/docs/latest/installation/desktop/windows-installation",
+      "/docs/latest/installation/desktop/win-installation",
     script: "winget install headlamp",
   },
   mac: {
@@ -69,9 +69,23 @@ const usePlatform = (): Platform => {
 };
 
 const latestReleasePromise = fetch(
-  "https://api.github.com/repos/kubernetes-sigs/headlamp/releases/latest"
-).then((response) => response.json());
+  'https://api.github.com/repos/kubernetes-sigs/headlamp/releases?per_page=10',
+)
+  .then((response) => response.json())
+  .then((releases) => {
+    if (!releases && !Array.isArray(releases)) return null;
 
+    return releases.find((release: unknown) => {
+      // Find a release for headlamp, which will have a tag name like v1.2.3
+      return (
+        release &&
+        typeof release === 'object' &&
+        'tag_name' in release &&
+        typeof release.tag_name === 'string' &&
+        /^v\d+\.\d+\.\d+$/.test(release.tag_name)
+      );
+    });
+  });
 const useLatestRelease = () => {
   const [latestRelease, setLatestRelease] = useState(null);
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/headlamp/issues/5914

Download button looks at the github release api endpoint to get URL for binary download but it was just loading latest release, which could be something else then headlamp release, like helm chart or plugin module. This PR fixes that logic and corrects fallback URL

repro steps in the issue