### PR TITLE
Improve UX of copy-to-clipboard button

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -133,3 +133,7 @@ figcaption {
   font-style: italic;
   opacity: 0.8;
 }
+
+.theme-code-block:hover div[class*="buttonGroup"] button {
+  opacity: 1;
+}


### PR DESCRIPTION
fixes #132 

before:
<img width="1056" height="404" alt="Screenshot from 2026-06-21 21-37-13" src="https://github.com/user-attachments/assets/db1f361f-a668-46cc-8916-26ff95f2edda" />

after:
<img width="1045" height="417" alt="Screenshot from 2026-06-21 21-36-23" src="https://github.com/user-attachments/assets/b3aa1ab5-8ac6-45d8-86d4-d69eed6dc0ff" />


