### PR TITLE
fix: add padding transition to prevent copy button overlap on hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,9 +14,7 @@ pre {
   font-variant-ligatures: none;
 }
 
-a:not(.card):not(.menu__link):not(.navbar__item):not(.button):not(
-    .table-of-contents__link
-  ):not(.navbar__brand):not(.pagination-nav__link):not(.breadcrumbs__link) {
+a:not(.card):not(.menu__link):not(.navbar__item):not(.button):not(.table-of-contents__link):not(.navbar__brand):not(.pagination-nav__link):not(.breadcrumbs__link) {
   text-decoration: underline;
 }
 
@@ -80,12 +78,13 @@ html[data-theme="dark"] {
 
 /* Make logo smaller on mobile so it fits with the search */
 @media screen and (max-width: 380px) {
-  .navbar__logo > img {
+  .navbar__logo>img {
     width: 120px;
   }
 }
+
 @media screen and (max-width: 340px) {
-  .navbar__logo > img {
+  .navbar__logo>img {
     width: 100px;
   }
 }
@@ -101,11 +100,13 @@ html[data-theme="dark"] {
   transition: box-shadow;
   transition-duration: 0.1s;
 }
+
 .button--primary:hover {
   color: #111;
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.2),
     0px 1px 3px 1px rgba(0, 0, 0, 0.1);
 }
+
 .button--primary:active {
   background-color: #d0c71f;
   box-shadow: none;
@@ -124,7 +125,7 @@ html[data-theme="dark"] {
   display: none;
 }
 
-figure > p {
+figure>p {
   margin: 0;
 }
 
@@ -132,4 +133,13 @@ figcaption {
   text-align: center;
   font-style: italic;
   opacity: 0.8;
+}
+
+/* Fix copy button overlap on code blocks */
+.theme-code-block pre {
+  transition: padding-right 0.2s ease;
+}
+
+.theme-code-block:hover pre {
+  padding-right: 3rem;
 }


### PR DESCRIPTION
## Description
Fixes #134

On hover, the copy button appears on top of code snippet text causing an overlap, making the text hard to read.

## Fix
Added a smooth padding-right transition on hover to the code block `pre` element, creating space for the copy button without any overlap.

**Changes:**
- `src/css/custom.css` — Added hover padding transition for `.theme-code-block pre`

## Before
Copy button overlaps code text on hover.

https://github.com/user-attachments/assets/0a1859a0-7870-404a-afd3-b0268d52390a



## After
Text smoothly shifts left on hover creating space for copy button. No overlap!

https://github.com/user-attachments/assets/1348c92e-c859-48ad-99bb-339ca2de748d

moothly shifts left on hover creating space for copy button. No overlap!


**Signed commits**
- [x] Yes, I signed my commits.